### PR TITLE
Changed status for external transfer call

### DIFF
--- a/functions/update-conference-participant.js
+++ b/functions/update-conference-participant.js
@@ -59,6 +59,9 @@ exports.handler = async function(context, event, callback) {
     .participants(participant)
     .update({
       endConferenceOnExit
+    }).catch(e => {
+       console.error(e);
+       return {};
     });
   console.log('Participant response properties:');
   Object.keys(participantResponse).forEach(key => {

--- a/src/components/ConferenceMonitor.js
+++ b/src/components/ConferenceMonitor.js
@@ -28,7 +28,7 @@ class ConferenceMonitor extends React.Component {
   }
 
   handleMoreThanTwoParticipants = (conferenceSid, participants) => {
-    console.log('More than two conference participants. Setting endConferenceOnExit to false for all participants.');
+    console.log(participants);
     this.setEndConferenceOnExit(conferenceSid, participants, false);
   }
 
@@ -40,7 +40,8 @@ class ConferenceMonitor extends React.Component {
   setEndConferenceOnExit = async(conferenceSid, participants, endConferenceOnExit) => {
     const promises = [];
     participants.forEach(p => {
-      console.log(`Participant ${p.callSid} status: ${p.status}`);
+      console.log(`setting endConferenceOnExit = ${endConferenceOnExit} for callSid: ${p.callSid} status: ${p.status}`);
+      if (p.connecting) {return} //skip setting end conference on connecting parties as it will fail
       promises.push(
         ConferenceService.setEndConferenceOnExit(conferenceSid, p.callSid, endConferenceOnExit)
       );

--- a/src/components/ConferenceMonitor.js
+++ b/src/components/ConferenceMonitor.js
@@ -28,7 +28,7 @@ class ConferenceMonitor extends React.Component {
   }
 
   handleMoreThanTwoParticipants = (conferenceSid, participants) => {
-    console.log(participants);
+    console.log('More than two conference participants. Setting endConferenceOnExit to false for all participants.');
     this.setEndConferenceOnExit(conferenceSid, participants, false);
   }
 

--- a/src/services/ConferenceService.js
+++ b/src/services/ConferenceService.js
@@ -113,7 +113,7 @@ class ConferenceService {
         const fakeSource = {
           connecting: true,
           participant_type: participantType,
-          status: 'connecting'
+          status: 'joined'
         };
         const fakeParticipant = new ConferenceParticipant(fakeSource, callSid);
         console.log('Adding fake participant:', fakeParticipant);


### PR DESCRIPTION
Changed participant status for the connecting external call.  

This prevents the situation where during a call transfer, if an Agent presses the Hang Up button before the external transferred call is answered, the conference is ended for all parties.

- Agent1 receives call from customer1
- Agent1 makes external call to customer2
- Agent1 press 'Leave Call' while the call is ringing, the call will continue ringing and connect between customer1 and customer2